### PR TITLE
Add FAQ page

### DIFF
--- a/routes.lisp
+++ b/routes.lisp
@@ -18,6 +18,10 @@
   (let ((body (load-view :pages/best-practices)))
     (send-response res :headers '(:content-type "text/html") :body body)))
 
+(defroute (:get "/faq") (req res)
+  (let ((body (load-view :pages/faq)))
+    (send-response res :headers '(:content-type "text/html") :body body)))
+
 (defroute (:get "/about") (req res)
   (let ((body (load-view :pages/about)))
     (send-response res :headers '(:content-type "text/html") :body body)))

--- a/views/layouts/default.lisp
+++ b/views/layouts/default.lisp
@@ -23,6 +23,7 @@
               (:li (:a :href "/" "Home"))
               (:li (:a :href "/docs" "Documentation"))
               (:li (:a :href "/best-practices" "Best practices"))
+              (:li (:a :href "/faq" "FAQ"))
               (:li (:a :href "/apps" "Apps"))
               (:li (:a :href "/about" "About"))
               ;(:li (:a :href "/guide" "Guide"))

--- a/views/pages/faq.md
+++ b/views/pages/faq.md
@@ -1,0 +1,21 @@
+---
+title: F.A.Q.
+layout: default
+---
+
+Frequently Asked Questions
+==========================
+
+- I want to explicitly import a symbol exported in package `wookie-plugin-export` but the package is empty until I run `(wookie:load-plugins)`?
+
+  You can use ASDF to call `load-plugins` before your system is loaded. To do so, one needs to define a :before `perform` method that specializes in your system and the prepare operation. One caveat is that because the asd file is read before package is loaded one can't call `(wookie:load-plugins)` as the package wookie doesn't exist, luckily ASDF come with `symcol-call` for this situations.
+
+```lisp
+;; An example: System foo
+(asdf:defsystem #:foo
+    ...)
+
+(defmethod perform :before ((op asdf:prepare-op)
+                            (system (eql (find-system :foo)))
+    (asdf/package:symbol-call :wookie 'load-plugins)))
+```


### PR DESCRIPTION
Recently I've been trying one package per file, but wookie's plugin system doesn't play well out of the box. I wanted to share a protip to make ASDF run load-plugins before 'your' system is loaded. Didn't know where it should go so I added a FAQ page and added the pro tip there. Hope it is of use.