### PR TITLE
Update request-handling.md

### DIFF
--- a/views/docs/request-handling.md
+++ b/views/docs/request-handling.md
@@ -32,11 +32,11 @@ The resource being requested. For example `/docs/search?class=listener` (the
 entire resource is gathered, even the GET vars).
 
 ##### request-headers (accessor)
-The HTTP headers that came in with this request. The headers are in plist format:
+The HTTP headers that came in with this request. The headers are in hash-table format:
 ```lisp
-(:host "musio.com"
+#{:host "musio.com"
  :accept "text/html"
- :connection "close")
+ :connection "close"}
 ```
 
 ##### request-data (accessor)


### PR DESCRIPTION
Update doc bit regarding headers being hash (instead of plist) - seen this in code, and even though there are some conditionals to test, whether headers are plist/hash coming from fast-http, it seems to be hashes for quite some time (https://github.com/fukamachi/fast-http/issues/1#issuecomment-59547166)